### PR TITLE
Flat file list

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   build:
     - {{ compiler('cxx')}}
   host:
-    - rust>=1.24.0
+    - rust<1.36.0
     - python
     - setuptools
   run:

--- a/mtsv/commands/cmd_specs/database.yml
+++ b/mtsv/commands/cmd_specs/database.yml
@@ -14,4 +14,9 @@ includedb:
   default: ["genbank","Complete Genome","Chromosome","Scaffold"]
   nargs: +
   help: Subsets of defaults can be specified for download or partitioning
+ff_list:
+  help: Used with build_only to create a local database from a filelist of GenBank Flat files
+taxonomy_path:
+  help: Used with build_only and should be a local mirror of ftp://ftp.ncbi.nih.gov/pub/taxonomy/ directory
+
 

--- a/mtsv/mtsv_prep/MTSv_prune.py
+++ b/mtsv/mtsv_prep/MTSv_prune.py
@@ -228,7 +228,7 @@ def clip(in_tx,ru_rank, ex_tx, name, min,maximum,fasta_path, pickle_path, chunk_
     if debug:
         return os.path.abspath(name)
     # try:
-    chunk_size *= 1000000000
+    chunk_size *= 10000000000
     if len(in_tx) ==1:
         temp = []
         try:

--- a/mtsv/mtsv_prep/MTSv_prune.py
+++ b/mtsv/mtsv_prep/MTSv_prune.py
@@ -228,7 +228,7 @@ def clip(in_tx,ru_rank, ex_tx, name, min,maximum,fasta_path, pickle_path, chunk_
     if debug:
         return os.path.abspath(name)
     # try:
-    chunk_size *= 10000000000
+    chunk_size *= 1000000000
     if len(in_tx) ==1:
         temp = []
         try:
@@ -274,6 +274,7 @@ def clip(in_tx,ru_rank, ex_tx, name, min,maximum,fasta_path, pickle_path, chunk_
     # print("Writing")
     chunk = 0
     srt_taxons = list(sorted(taxons))
+    ret_list = []
     with open(fasta_path, "rb") as fasta:
         while srt_taxons:
             name = "_{}.".format(chunk).join(name.rsplit(".",1))
@@ -313,10 +314,11 @@ def clip(in_tx,ru_rank, ex_tx, name, min,maximum,fasta_path, pickle_path, chunk_
                             line_count = 0
                             seq = bytearray()
                 chunk += 1
-            srt_taxons = list(sorted(taxons))
+
+            ret_list.append(os.path.abspath(name))
             name = "{}.fasta".format(name.rsplit("_", 1)[0])
             # chunk +=
-    return os.path.abspath(name)
+    return ret_list
 # except:
     #     return 0
 # writes a new or updates json config file
@@ -324,7 +326,6 @@ def gen_json(configuration, args):
     if args.update and args.configuration_path:
         with open(args.configuration_path, "w") as file:
             json.dump(configuration, file, sort_keys=True)
-
     else:
         with open(args.output + ".json", "w") as file:
             json.dump(configuration, file, sort_keys=True, indent=4)

--- a/mtsv/mtsv_prep/MTSv_prune.py
+++ b/mtsv/mtsv_prep/MTSv_prune.py
@@ -304,7 +304,7 @@ def clip(in_tx,ru_rank, ex_tx, name, min,maximum,fasta_path, pickle_path, chunk_
                                 line = fasta.readline()
                                 line_count += len(line.strip())
 
-                            if len(seq)-line_count >= min and len(seq)-float(line_count)<= maximum:
+                            if line_count >= min and float(line_count)<= maximum:
                                 gi = header.split(b' ',2)[1].split(b':')[1]
                                 # gi = header.split(b' ',1)[0].strip(b'>')
                                 out.write(b'>'+gi+b'-'+rr_tx+b'\n')

--- a/mtsv/mtsv_prep/MTSv_prune.py
+++ b/mtsv/mtsv_prep/MTSv_prune.py
@@ -279,7 +279,7 @@ def clip(in_tx,ru_rank, ex_tx, name, min,maximum,fasta_path, pickle_path, chunk_
             name = "_{}.".format(chunk).join(name.rsplit(".",1))
             byte_count = 0
             with open(name, "wb") as out:
-                while byte_count < chunk_size:
+                while srt_taxons and byte_count < chunk_size:
                     tx = srt_taxons.pop()
                     if tx:
                         tx = tx.encode().strip()
@@ -314,6 +314,7 @@ def clip(in_tx,ru_rank, ex_tx, name, min,maximum,fasta_path, pickle_path, chunk_
                             seq = bytearray()
                 chunk += 1
             srt_taxons = list(sorted(taxons))
+            name = "{}.fasta".format(name.rsplit("_", 1)[0])
             # chunk +=
     return os.path.abspath(name)
 # except:

--- a/mtsv/mtsv_prep/MTSv_prune.py
+++ b/mtsv/mtsv_prep/MTSv_prune.py
@@ -123,17 +123,21 @@ def binary_search(a, x, lo=0, hi=None):   # can't use a to specify default for h
     lo = 0
     mid = (hi-lo)//2
     while True:
-        if lo >= hi:
-            if a[mid][0] == x: return mid
-            else: return -1
-        if a[mid][0] == x:
-            return mid
-        elif a[mid][0] < x:
-            lo = mid +1
-        else:
-            hi = mid -1
-        mid = ((hi - lo) // 2)+lo
+        try:
+            if lo >= hi:
+                if a[mid] == x: return mid
+                else: return -1
+            if a[mid] == x:
+                return mid
+            elif a[mid] < x:
+                lo = mid +1
+            else:
+                hi = mid -1
+            mid = ((hi - lo) // 2)+lo
+        except:
+            print(x,lo,hi,mid)
 
+            break
 def taxids2name(dump_path):
     dump = tarfile.open(dump_path, "r:gz")
     tax_ids = {}
@@ -247,8 +251,7 @@ def clip(in_tx,ru_rank, ex_tx, name, min,maximum,fasta_path, pickle_path, chunk_
             ex_tx = temp
         except FileNotFoundError:
             pass
-    # print(pickle_path)
-    # print("Getting Offsets and Tree")
+
     tx_ids, child2parent, positions = deserialization(pickle_path)
 
     taxons = set()
@@ -271,56 +274,92 @@ def clip(in_tx,ru_rank, ex_tx, name, min,maximum,fasta_path, pickle_path, chunk_
 
     seq = bytearray()
     line_count = 0
-    # print("Writing")
+    bins = first_fit(list(taxons), positions, os.path.getsize(fasta_path), chunk_size)
     chunk = 0
-    srt_taxons = list(sorted(taxons))
     ret_list = []
     with open(fasta_path, "rb") as fasta:
-        while srt_taxons:
-            name = "_{}.".format(chunk).join(name.rsplit(".",1))
-            byte_count = 0
-            with open(name, "wb") as out:
-                while srt_taxons and byte_count < chunk_size:
-                    tx = srt_taxons.pop()
-                    if tx:
-                        tx = tx.encode().strip()
-                        try:
+        for bin in bins:
+            srt_taxons = list(sorted(bin))
+            while srt_taxons:
+                name = "_{}.".format(chunk).join(name.rsplit(".",1))
+                # byte_count = 0
+                with open(name, "wb") as out:
+                    while srt_taxons:
+                        tx = srt_taxons.pop()
+                        if tx:
+                            tx = tx.encode().strip()
+                            try:
+                                positions[tx].sort()
+                            except KeyError:
+                                continue
+                            if ru_rank:
+                                rr_tx = roll_up(tx, ru_rank, child2parent)
+                            else:
+                                rr_tx = tx
+                            if not rr_tx:
+                                continue
                             positions[tx].sort()
-                        except KeyError:
-                            continue
-                        if ru_rank:
-                            rr_tx = roll_up(tx, ru_rank, child2parent)
-                        else:
-                            rr_tx = tx
-                        if not rr_tx:
-                            continue
-                        # print()
-                        positions[tx].sort()
-                        for off in positions[tx]:
-                            fasta.seek(off)
-                            header = fasta.readline()
-                            line = fasta.readline()
-                            while line and chr(line[0]) != ">":
-                                seq += line
+                            for off in positions[tx]:
+                                fasta.seek(off)
+                                header = fasta.readline()
                                 line = fasta.readline()
-                                line_count += len(line.strip())
+                                while line and chr(line[0]) != ">":
+                                    seq += line
+                                    line = fasta.readline()
+                                    line_count += len(line.strip())
 
-                            if line_count >= min and float(line_count)<= maximum:
-                                gi = header.split(b' ',2)[1].split(b':')[1]
-                                # gi = header.split(b' ',1)[0].strip(b'>')
-                                out.write(b'>'+gi+b'-'+rr_tx+b'\n')
-                                out.write(seq)
-                                byte_count += len(b'>'+gi+b'-'+rr_tx+b'\n') + line_count
-                            line_count = 0
-                            seq = bytearray()
-                chunk += 1
+                                if line_count >= min and float(line_count)<= maximum:
+                                    gi = header.split(b' ',2)[1].split(b':')[1]
+                                    out.write(b'>'+gi+b'-'+rr_tx+b'\n')
+                                    out.write(seq)
+                                line_count = 0
+                                seq = bytearray()
+                    chunk += 1
 
             ret_list.append(os.path.abspath(name))
             name = "{}.fasta".format(name.rsplit("_", 1)[0])
-            # chunk +=
     return ret_list
-# except:
-    #     return 0
+
+def first_fit(taxa_list, positions, file_size, threshold):
+    pos = []
+    for key in positions.keys():
+        pos += positions[key]
+    pos.sort()
+    tax2bytes = {x:0 for x in taxa_list}
+    # print(positions)
+
+    for tax in taxa_list:
+        ind = -1
+        try:
+            positions[tax.encode()]
+        except KeyError:
+            continue
+        for offset in positions[tax.encode()]:
+            # print(tax)
+            ind = binary_search(pos, offset)
+            if ind != -1:
+                try:
+                    tax2bytes[tax] += pos[ind+1] - pos[ind]
+                except IndexError:
+                    tax2bytes[tax] += file_size - pos[ind]
+    sorted_taxon = sorted(tax2bytes.items(), key=lambda kv: kv[1], reverse=True)
+
+    bins = [set()]
+    bins_size = [0]
+    found = False
+    for item in sorted_taxon:
+        for ind, bin in enumerate(bins):
+            if bins_size[ind]+item[1] <= threshold:
+                bin.add(item[0])
+                bins_size[ind] += item[1]
+                found = True
+                break
+        if not found:
+            bins.append({item[0]})
+            bins_size.append(item[1])
+        found = False
+    return bins
+
 # writes a new or updates json config file
 def gen_json(configuration, args):
     if args.update and args.configuration_path:

--- a/mtsv/mtsv_prep/main.py
+++ b/mtsv/mtsv_prep/main.py
@@ -140,10 +140,10 @@ def partition(args):
                     os.makedirs(path)
                 except:
                     pass
-                if os.path.isfile(os.path.join(chunk_path, "{0}_0.fasta".format(prt))) and not args.overwrite:
-                    fin.add(os.path.abspath(os.path.join(path, "{0}.fas".format(prt))))
-                else:
-                    partition_list.append ( (list(inc), args.rollup_rank, list(exc), os.path.join(chunk_path,
+                # if os.path.isfile(os.path.join(chunk_path, "{0}_0.fasta".format(prt))) and not args.overwrite:
+                #     fin.add(os.path.abspath(os.path.join(path, "{0}.fas".format(prt))))
+                # else:
+                partition_list.append ( (list(inc), args.rollup_rank, list(exc), os.path.join(chunk_path,
                                             "{0}.fasta".format(prt)),arguments['minimum-length'],
                                              arguments['maximum-length'], arguments["fasta-path"],
                                              arguments["serialization-path"], args.chunk_size ,args.debug)  )
@@ -155,17 +155,19 @@ def partition(args):
     tmp = []
     for x in ret_list:
         tmp += x
-    return ",".join(list(set(ret_list + list(fin)))), args
-
+    # out_str = ",".join(list(set(tmp + list(fin) )))
+    # return out_str, args
+    return list(set(tmp).union(fin)), args
 def chunk(file_list, args):
     dir_set = set()
-    for csv in file_list:
-        for fp in csv.split(","):
-            db = os.path.basename(os.path.dirname(fp))
-            out_dir = os.path.abspath(os.path.join(args.path, "indices", db,os.path.basename(fp).rsplit(".",1)[0] ))
-            # if not os.path.isfile( os.path.join(out_dir,"_0.".join(os.path.basename(fp).rsplit(".", 1))+"ta" ) ):
-            #     subprocess.run("{2} --input {0} --output {1} --gb {3}".format(fp, out_dir, 'mtsv-chunk', args.chunk_size).split() )
-            dir_set.add(out_dir)
+    for fp in file_list:
+    # for fp in csv.split(","):
+    #     db = os.path.basename(os.path.dirname(fp))
+        out_dir = os.path.dirname(fp)
+        # out_dir = os.path.abspath(os.path.join(args.path, "indices", db,os.path.basename(fp).rsplit(".",1)[0] ))
+        # if not os.path.isfile( os.path.join(out_dir,"_0.".join(os.path.basename(fp).rsplit(".", 1))+"ta" ) ):
+        #     subprocess.run("{2} --input {0} --output {1} --gb {3}".format(fp, out_dir, 'mtsv-chunk', args.chunk_size).split() )
+        dir_set.add(out_dir)
     return list(dir_set)
 
 # def snake(args):
@@ -214,6 +216,7 @@ def chunk(file_list, args):
 
 def fm_build(dir_list):
     fm_list = []
+    # print(dir_list)
     for directory in dir_list:
         for fp in iglob(os.path.join(directory, "*.fasta")):
             out_file = os.path.join(directory, "{0}.index".format(os.path.basename(fp).split(".")[0]))
@@ -223,8 +226,8 @@ def fm_build(dir_list):
                         os.path.abspath(fp),
                         out_file,
                         'mtsv-build').split() )
-                if result.returncode == 0:
-                    os.remove(os.path.abspath(fp))
+                # if result.returncode == 0:
+                #     os.remove(os.path.abspath(fp))
             fm_list.append(out_file)
     return fm_list
 

--- a/mtsv/mtsv_prep/main.py
+++ b/mtsv/mtsv_prep/main.py
@@ -113,14 +113,13 @@ def oneclickbuild(args):
 
 def ff_build(args):
     os.makedirs(os.path.join(args.path,"artifacts"), exist_ok=True)
-    artifacts = [(os.path.join(args.path ,"artifacts", "taxdump.tar.gz"), os.path.abspath(os.path.join(args.taxonomy_path,"taxdump.tar.gz" )))]
-    tax_path = os.path.join(args.taxonomy_path, "accession2taxid/")
-    for file in iglob(tax_path):
+    artifacts = [(os.path.abspath(os.path.join(args.path ,"artifacts", "taxdump.tar.gz")), os.path.abspath(os.path.join(args.taxonomy_path,"taxdump.tar.gz" )))]
+    tax_path = os.path.abspath(os.path.join(args.taxonomy_path, "accession2taxid/","*accession2taxid*"))
+    for file in iglob(tax_path+'**', recursive=True):
         if not os.path.isdir(file) and not fnmatch.fnmatch(os.path.basename(file), 'dead*') and not fnmatch.fnmatch(file, '*md5'):
-            artifacts.append((os.path.join(args.path, "artifacts",os.path.basename(file)), os.path.abspath(file)))
+            artifacts.append((os.path.abspath(os.path.join(args.path, "artifacts",os.path.basename(file))), os.path.abspath(file),))
     for file in artifacts:
         copyfile(file[1],file[0])
-
     with open(os.path.join(args.path, "artifacts","decompression.log"), "w" ):
         pass
     pool = Pool(args.threads)

--- a/mtsv/mtsv_prep/main.py
+++ b/mtsv/mtsv_prep/main.py
@@ -146,7 +146,7 @@ def partition(args):
                     partition_list.append ( (list(inc), args.rollup_rank, list(exc), os.path.join(chunk_path,
                                             "{0}.fasta".format(prt)),arguments['minimum-length'],
                                              arguments['maximum-length'], arguments["fasta-path"],
-                                             arguments["serialization-path"], args.debug)  )
+                                             arguments["serialization-path"], args.chunk_size ,args.debug)  )
             except OSError:
                 print("Partion folder {0} exists please use --overwrite to repartition".format(path))
 

--- a/mtsv/mtsv_prep/main.py
+++ b/mtsv/mtsv_prep/main.py
@@ -136,10 +136,10 @@ def partition(args):
                     os.makedirs(chunk_path, exist_ok=True)
                     prt = "{0}".format("_".join(sorted(inc)) )
                 path = os.path.join(args.path, "fastas", db)
-                try:
-                    os.makedirs(path)
-                except:
-                    pass
+                # try:
+                #     os.makedirs(path)
+                # except:
+                #     pass
                 # if os.path.isfile(os.path.join(chunk_path, "{0}_0.fasta".format(prt))) and not args.overwrite:
                 #     fin.add(os.path.abspath(os.path.join(path, "{0}.fas".format(prt))))
                 # else:

--- a/mtsv/mtsv_prep/main.py
+++ b/mtsv/mtsv_prep/main.py
@@ -140,11 +140,11 @@ def partition(args):
                     os.makedirs(path)
                 except:
                     pass
-                if os.path.isfile(os.path.join(path, "{0}.fas".format(prt))) and not args.overwrite:
+                if os.path.isfile(os.path.join(chunk_path, "{0}_0.fasta".format(prt))) and not args.overwrite:
                     fin.add(os.path.abspath(os.path.join(path, "{0}.fas".format(prt))))
                 else:
-                    partition_list.append ( (list(inc), args.rollup_rank, list(exc), os.path.join(path,
-                                            "{0}.fas".format(prt)),arguments['minimum-length'],
+                    partition_list.append ( (list(inc), args.rollup_rank, list(exc), os.path.join(chunk_path,
+                                            "{0}.fasta".format(prt)),arguments['minimum-length'],
                                              arguments['maximum-length'], arguments["fasta-path"],
                                              arguments["serialization-path"], args.debug)  )
             except OSError:
@@ -165,48 +165,48 @@ def chunk(file_list, args):
         dir_set.add(out_dir)
     return list(dir_set)
 
-def snake(args):
-    chunk_path = 'mtsv-chunk'
-    fm_build_path = 'mtsv-build'
-    print(chunk_path)
-    print(fm_build_path)
-    print(args)
-
-    print(partition(args))
-    # for i in args:
-    #     print(i)
-    workflow = Workflow(
-        "__file__",
-        overwrite_workdir=args.working_dir)
-    if args.cluster_cfg is not None:
-        workflow.cluster_cfg = args.cluster_cfg
-    snakemake.workflow.rules = Rules()
-    snakemake.workflow.config = dict()
-
-
-
-
-    # @workflow.rule(name='chunking')
-    # @workflow.docstring("""Fasta chunking""")
-    # @workflow.input(os.path.join("test", "{}.index"))
-    # @workflow.output(os.path.join(cmd.params['binning_outpath'], "{index}.bn"))
-    # @workflow.params(call=chunk_path, args=args.chunk_size)
-    # @workflow.message("Executing Fasta chunking on the follow files {input}.")
-    # @workflow.log(os.path.join(args.path,"artifacts/logs/""{index}.log"))
-    # @workflow.threads(1)
-    # @workflow.shellcmd("{params.call} --input {input} --output{output} --gb {params.args} > {log} 2>&1")
-    # @workflow.run
-    # def __rule_chunking(input, output, params, wildcards,
-    #                    threads, resources, log, version, rule,
-    #                    conda_env, singularity_img, singularity_args,
-    #                    use_singularity, bench_record, jobid, is_shell):
-    #     shell(
-    #         "{params.call} --input {input} --output{output} --gb {params.args} > {log} 2>&1"
-    #     )
-    #
-    # workflow.check()
-    # print("Dry run first ...")
-    # workflow.execute(dryrun=True, updated_files=[])
+# def snake(args):
+#     chunk_path = 'mtsv-chunk'
+#     fm_build_path = 'mtsv-build'
+#     print(chunk_path)
+#     print(fm_build_path)
+#     print(args)
+#
+#     print(partition(args))
+#     # for i in args:
+#     #     print(i)
+#     workflow = Workflow(
+#         "__file__",
+#         overwrite_workdir=args.working_dir)
+#     if args.cluster_cfg is not None:
+#         workflow.cluster_cfg = args.cluster_cfg
+#     snakemake.workflow.rules = Rules()
+#     snakemake.workflow.config = dict()
+#
+#
+#
+#
+#     # @workflow.rule(name='chunking')
+#     # @workflow.docstring("""Fasta chunking""")
+#     # @workflow.input(os.path.join("test", "{}.index"))
+#     # @workflow.output(os.path.join(cmd.params['binning_outpath'], "{index}.bn"))
+#     # @workflow.params(call=chunk_path, args=args.chunk_size)
+#     # @workflow.message("Executing Fasta chunking on the follow files {input}.")
+#     # @workflow.log(os.path.join(args.path,"artifacts/logs/""{index}.log"))
+#     # @workflow.threads(1)
+#     # @workflow.shellcmd("{params.call} --input {input} --output{output} --gb {params.args} > {log} 2>&1")
+#     # @workflow.run
+#     # def __rule_chunking(input, output, params, wildcards,
+#     #                    threads, resources, log, version, rule,
+#     #                    conda_env, singularity_img, singularity_args,
+#     #                    use_singularity, bench_record, jobid, is_shell):
+#     #     shell(
+#     #         "{params.call} --input {input} --output{output} --gb {params.args} > {log} 2>&1"
+#     #     )
+#     #
+#     # workflow.check()
+#     # print("Dry run first ...")
+#     # workflow.execute(dryrun=True, updated_files=[])
     # return workflow
 
 def fm_build(dir_list):
@@ -426,6 +426,9 @@ def main(argv=None):
     p = subparsers.add_parser("json_update")
     p.add_argument("--path")
     p = subparsers.add_parser("oneclick")
+    p = subparsers.add_parser("ff_list")
+    p.add_argument("--path")
+
     for command, cmd_class in COMMANDS.items():
         for arg, desc in get_global_config(cmd_class.config_section).items():
             if "_meta" in arg:

--- a/mtsv/mtsv_prep/main.py
+++ b/mtsv/mtsv_prep/main.py
@@ -152,17 +152,20 @@ def partition(args):
 
     p = Pool(args.threads)
     ret_list = p.starmap(clip, partition_list)
-
-    return ret_list + list(fin), args
+    tmp = []
+    for x in ret_list:
+        tmp += x
+    return ",".join(list(set(ret_list + list(fin)))), args
 
 def chunk(file_list, args):
     dir_set = set()
-    for fp in file_list:
-        db = os.path.basename(os.path.dirname(fp))
-        out_dir = os.path.abspath(os.path.join(args.path, "indices", db,os.path.basename(fp).rsplit(".",1)[0] ))
-        if not os.path.isfile( os.path.join(out_dir,"_0.".join(os.path.basename(fp).rsplit(".", 1))+"ta" ) ):
-            subprocess.run("{2} --input {0} --output {1} --gb {3}".format(fp, out_dir, 'mtsv-chunk', args.chunk_size).split() )
-        dir_set.add(out_dir)
+    for csv in file_list:
+        for fp in csv.split(","):
+            db = os.path.basename(os.path.dirname(fp))
+            out_dir = os.path.abspath(os.path.join(args.path, "indices", db,os.path.basename(fp).rsplit(".",1)[0] ))
+            # if not os.path.isfile( os.path.join(out_dir,"_0.".join(os.path.basename(fp).rsplit(".", 1))+"ta" ) ):
+            #     subprocess.run("{2} --input {0} --output {1} --gb {3}".format(fp, out_dir, 'mtsv-chunk', args.chunk_size).split() )
+            dir_set.add(out_dir)
     return list(dir_set)
 
 # def snake(args):


### PR DESCRIPTION
Currently working prototype that forgoes the usage of mtsv-chunk. Currently, testing on txid 2 using genbank, chromosomes and complete genomes currently on monsoon. Smaller tests using bacillus txid 1386 worked to completion. Observed issue is that the chunks may be fairly uneven due to being written as taxids. I plan to implement a first fit chunking based on taxids and then do a final pass using mtsv-chunk to get below the chunk threshold. As is, this circumvents the issue of loading the entire assembly level fasta into memory for chunking.